### PR TITLE
Feat: Add typescript declarations and Prettier, resolves #40

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 120,
+  "plugins": ["prettier-plugin-astro"],
+  "pluginSearchDirs": false
+}

--- a/Accordion.astro
+++ b/Accordion.astro
@@ -1,3 +1,11 @@
+---
+import type { AccordionItem } from '.'
+
+interface Props {
+  children: AccordionItem | AccordionItem[]
+}
+---
+
 <div class="accordion">
   <ul class="accordion__wrapper">
     <slot />

--- a/Accordion.astro
+++ b/Accordion.astro
@@ -9,12 +9,12 @@
   const accordionItems = [...document.querySelectorAll('.accordion__item')]
 
   // functions
-  const getPanelHeight = accordionItem => {
+  const getPanelHeight = (accordionItem) => {
     const accordionInner = accordionItem.querySelector('.panel__inner')
     return accordionInner.getBoundingClientRect().height
   }
 
-  const openAccordionItem = accordionItem => {
+  const openAccordionItem = (accordionItem) => {
     const accordionItemHeader = accordionItem.querySelector('.accordion__header')
     const accordionToggleIndicator = accordionItem.querySelector('.header__toggle-indicator')
     const accordionPanel = accordionItem.querySelector('.accordion__panel')
@@ -25,7 +25,7 @@
     accordionToggleIndicator.innerHTML = `<svg class="header__toggle-indicator" aria-hidden="true" data-prefix="fas" data-icon="minus" class="svg-inline--fa fa-minus fa-w-14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"/></svg>`
   }
 
-  const closeAccordionItem = accordionItem => {
+  const closeAccordionItem = (accordionItem) => {
     const accordionItemHeader = accordionItem.querySelector('.accordion__header')
     const accordionToggleIndicator = accordionItem.querySelector('.header__toggle-indicator')
     const accordionPanel = accordionItem.querySelector('.accordion__panel')
@@ -37,23 +37,21 @@
     accordionToggleIndicator.innerHTML = `<svg class="header__toggle-indicator" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"/></svg>`
   }
 
-  const isAccordionOpen = accordionItem => {
+  const isAccordionOpen = (accordionItem) => {
     return accordionItem.classList.contains('is-active')
   }
 
-  function toggleAccordionItem () {
+  function toggleAccordionItem() {
     const accordionItem = event.target.closest('.accordion__item')
     if (!accordionItem || event.target.closest('.accordion__panel')) return
 
-    isAccordionOpen(accordionItem)
-      ? closeAccordionItem(accordionItem)
-      : openAccordionItem(accordionItem)
+    isAccordionOpen(accordionItem) ? closeAccordionItem(accordionItem) : openAccordionItem(accordionItem)
   }
 
-  function recalculateHeight () {
-    const toggledAccordionItems = accordionItems.filter(element => element.classList.contains('is-active'))
+  function recalculateHeight() {
+    const toggledAccordionItems = accordionItems.filter((element) => element.classList.contains('is-active'))
 
-    toggledAccordionItems.forEach(toggledAccordionItem => {
+    toggledAccordionItems.forEach((toggledAccordionItem) => {
       const accordionPanel = toggledAccordionItem.querySelector('.accordion__panel')
       accordionPanel.style.height = `${getPanelHeight(toggledAccordionItem)}px`
     })
@@ -71,7 +69,7 @@
     accordionItemPanel.setAttribute('aria-labelledby', `accordion-item${index + 1}`)
   })
 
-  document.addEventListener('keydown', event => {
+  document.addEventListener('keydown', (event) => {
     const accordionItem = event.target.closest('.accordion__item')
 
     if (event.key !== 'Escape') return
@@ -82,13 +80,13 @@
     }
   })
 
-  document.addEventListener('keydown', event => {
+  document.addEventListener('keydown', (event) => {
     if (!event.target.closest('.accordion__header')) return
 
     const accordionWrapper = event.target.closest('.accordion__wrapper')
     const accordionItem = event.target.closest('.accordion__item')
     const accordionItems = [...accordionWrapper.querySelectorAll('.accordion__item')]
-    const index = accordionItems.findIndex(element => element === accordionItem)
+    const index = accordionItems.findIndex((element) => element === accordionItem)
 
     const { key } = event
 

--- a/AccordionItem.astro
+++ b/AccordionItem.astro
@@ -1,5 +1,5 @@
 ---
-const {header} = Astro.props
+const { header } = Astro.props
 ---
 
 <li class="accordion__item">
@@ -13,16 +13,14 @@ const {header} = Astro.props
     >
       {header}
       <svg class="header__toggle-indicator" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
-        <path fill="currentColor" d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"/>
+        <path
+          fill="currentColor"
+          d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+        ></path>
       </svg>
     </button>
   </h3>
-  <div
-    id="accordion-panel-1"
-    role="region"
-    class="accordion__panel"
-    aria-labelledby="accordion-header-1"
-  >
+  <div id="accordion-panel-1" role="region" class="accordion__panel" aria-labelledby="accordion-header-1">
     <div class="panel__inner">
       <slot />
     </div>
@@ -50,7 +48,7 @@ const {header} = Astro.props
     outline-offset: -6px;
     box-shadow: inset 0 0 0 2px white;
   }
-  
+
   .accordion__item:only-of-type .accordion__header,
   .accordion__item:last-of-type .accordion__header {
     border: 2px solid #202020;

--- a/AccordionItem.astro
+++ b/AccordionItem.astro
@@ -1,4 +1,9 @@
 ---
+interface Props {
+  header: string
+  children: any
+}
+
 const { header } = Astro.props
 ---
 

--- a/Breadcrumbs.astro
+++ b/Breadcrumbs.astro
@@ -1,3 +1,11 @@
+---
+import type { BreadcrumbsItem } from '.'
+
+interface Props {
+  children: BreadcrumbsItem | BreadcrumbsItem[]
+}
+---
+
 <nav class="breadcrumbs" aria-label="Breadcrumbs">
   <ol>
     <slot />

--- a/BreadcrumbsItem.astro
+++ b/BreadcrumbsItem.astro
@@ -1,17 +1,9 @@
 ---
-const {
-  href = '#',
-  label = 'Breadcrumb',
-  currentPage = false,
-} = Astro.props
+const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
 ---
 
 <li class="breadcrumbs__item">
-  {
-    currentPage
-      ? <span>{label}</span>
-      : <a href={href}>{label}</a>
-  }
+  {currentPage ? <span>{label}</span> : <a href={href}>{label}</a>}
 </li>
 
 <style is:global>

--- a/BreadcrumbsItem.astro
+++ b/BreadcrumbsItem.astro
@@ -1,4 +1,10 @@
 ---
+interface Props {
+  href?: string
+  label: string
+  currentPage?: boolean
+}
+
 const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
 ---
 

--- a/Card.astro
+++ b/Card.astro
@@ -1,4 +1,12 @@
 ---
+interface Props {
+  url?: string
+  img?: string
+  title?: string
+  footer: string
+  children?: HTMLElement | HTMLElement[]
+}
+
 const { url = '#', img = 'https://fakeimg.pl/640x360', title = 'Default title', footer = 'Your name' } = Astro.props
 ---
 

--- a/Card.astro
+++ b/Card.astro
@@ -1,15 +1,10 @@
 ---
-const { 
-  url = '#', 
-  img = 'https://fakeimg.pl/640x360', 
-  title = 'Default title', 
-  footer = 'Your name'
-} = Astro.props
+const { url = '#', img = 'https://fakeimg.pl/640x360', title = 'Default title', footer = 'Your name' } = Astro.props
 ---
 
 <div class="card">
   <div class="card__image">
-    <img src={img} alt="">
+    <img src={img} alt="" />
   </div>
   <div class="card__content">
     <h3>

--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -1,5 +1,10 @@
 <button class="darkmode-toggle" aria-pressed="false" aria-label="Enable dark mode">
-  <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M9.353 3C5.849 4.408 3 7.463 3 11.47A9.53 9.53 0 0 0 12.53 21c4.007 0 7.062-2.849 8.47-6.353C8.17 17.065 8.14 8.14 9.353 3z"/></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"
+    ><path
+      fill="currentColor"
+      d="M9.353 3C5.849 4.408 3 7.463 3 11.47A9.53 9.53 0 0 0 12.53 21c4.007 0 7.062-2.849 8.47-6.353C8.17 17.065 8.14 8.14 9.353 3z"
+    ></path></svg
+  >
 </button>
 
 <script is:inline>
@@ -30,8 +35,6 @@
   darkModeToggle.addEventListener('click', () => {
     darkMode = localStorage.getItem('darkMode')
 
-    darkMode !== 'enabled'
-      ? enableDarkMode()
-      : disableDarkMode()
+    darkMode !== 'enabled' ? enableDarkMode() : disableDarkMode()
   })
 </script>

--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -1,3 +1,7 @@
+---
+type Props = Record<string, never>
+---
+
 <button class="darkmode-toggle" aria-pressed="false" aria-label="Enable dark mode">
   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"
     ><path

--- a/Media.astro
+++ b/Media.astro
@@ -1,4 +1,10 @@
 ---
+interface Props {
+  class: string
+  src?: string
+  alt?: string
+}
+
 const { class: classNames, src = 'https://shorturl.at/tCPS2', alt = '' } = Astro.props
 ---
 

--- a/Media.astro
+++ b/Media.astro
@@ -1,15 +1,5 @@
 ---
-const {
-  class: classNames,
-  src = 'https://shorturl.at/tCPS2',
-  alt = ''
-} = Astro.props
+const { class: classNames, src = 'https://shorturl.at/tCPS2', alt = '' } = Astro.props
 ---
 
-<img
-  class={classNames}
-  src={src}
-  alt={alt}
-  loading="lazy"
-  decoding="async"
->
+<img class={classNames} src={src} alt={alt} loading="lazy" decoding="async" />

--- a/Modal.astro
+++ b/Modal.astro
@@ -1,9 +1,5 @@
 ---
-const {
-  triggerId,
-  title,
-  closeText = 'Close'
-} = Astro.props
+const { triggerId, title, closeText = 'Close' } = Astro.props
 ---
 
 <div class="modal" role="dialog" aria-labelledby={triggerId}>
@@ -27,21 +23,20 @@ const {
   const modalId = modal.getAttribute('aria-labelledby')
   const modalCloseButton = modal.querySelector('.modal__close button')
   const modalTrigger = document.querySelector(`#${modalId}`)
-  
+
   // functions
-  const teleportToRoot = element => {
+  const teleportToRoot = (element) => {
     element.remove()
     body.appendChild(element)
   }
 
-  const getKeyboardFocusableElements = element => {
-    return [...element.querySelectorAll(
-      'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
-    )]
-      .filter(el => !el.hasAttribute('disabled'))
+  const getKeyboardFocusableElements = (element) => {
+    return [
+      ...element.querySelectorAll('a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'),
+    ].filter((el) => !el.hasAttribute('disabled'))
   }
 
-  const trapFocus = event => {
+  const trapFocus = (event) => {
     const focusables = getKeyboardFocusableElements(modal)
     const firstFocusable = focusables[0]
     const lastFocusable = focusables[focusables.length - 1]
@@ -57,7 +52,7 @@ const {
     }
   }
 
-  const openModal = _ => {
+  const openModal = (_) => {
     const modalTitle = modal.querySelector('h3')
 
     modal.classList.add('show')
@@ -65,14 +60,14 @@ const {
     modalTitle.focus()
     document.addEventListener('keydown', trapFocus)
 
-    modal.addEventListener('keydown', event => {
+    modal.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {
         closeModal()
       }
     })
   }
 
-  const closeModal = _ => {
+  const closeModal = (_) => {
     modal.classList.remove('show')
     body.classList.remove('modal-is-active')
     modalTrigger.focus({ preventScroll: true })
@@ -86,7 +81,7 @@ const {
 
   modalCloseButton.addEventListener('click', closeModal)
 
-  modal.addEventListener('click', event => { 
+  modal.addEventListener('click', (event) => {
     if (!event.target.closest('.modal__content')) {
       closeModal()
     }

--- a/Modal.astro
+++ b/Modal.astro
@@ -1,4 +1,11 @@
 ---
+interface Props {
+  triggerId: string
+  title: string
+  closeText?: string
+  children?: HTMLElement | HTMLElement[]
+}
+
 const { triggerId, title, closeText = 'Close' } = Astro.props
 ---
 

--- a/Notification.astro
+++ b/Notification.astro
@@ -1,4 +1,12 @@
 ---
+interface Props {
+  // role="region" not supported as element takes no id
+  type?: 'info' | 'success' | 'warning' | 'error' | 'default'
+  role?: 'none' | 'alert' | 'log' | 'marquee' | 'status' | 'timer'
+  ariaLive?: 'off' | 'polite' | 'assertive'
+  children?: any
+}
+
 const { type = 'default', role = 'none', ariaLive = 'off' } = Astro.props
 ---
 

--- a/Notification.astro
+++ b/Notification.astro
@@ -1,9 +1,5 @@
 ---
-const {
-  type = 'default',
-  role = 'none',
-  ariaLive = 'off'
-} = Astro.props
+const { type = 'default', role = 'none', ariaLive = 'off' } = Astro.props
 ---
 
 <div class={`notification type-${type}`} role={role} aria-live={ariaLive}>

--- a/Pagination.astro
+++ b/Pagination.astro
@@ -5,7 +5,7 @@ const {
   nextPage = '#',
   lastPage = '#',
   currentPage = '1',
-  totalPages = '12'
+  totalPages = '12',
 } = Astro.props
 ---
 
@@ -13,16 +13,90 @@ const {
   <ul class="pagination__list">
     <li>
       {
-        firstPage
-          ? <a href={firstPage} aria-label="Go to the first page"><svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M24.6667 9L18 15.6667L24.6667 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/><path d="M14.6667 9L8 15.6667L14.6667 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
-          : <span class="disabled"><svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M24.6667 9L18 15.6667L24.6667 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/><path d="M14.6667 9L8 15.6667L14.6667 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+        firstPage ? (
+          <a href={firstPage} aria-label="Go to the first page">
+            <svg
+              aria-hidden="true"
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24.6667 9L18 15.6667L24.6667 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M14.6667 9L8 15.6667L14.6667 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </a>
+        ) : (
+          <span class="disabled">
+            <svg
+              aria-hidden="true"
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24.6667 9L18 15.6667L24.6667 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M14.6667 9L8 15.6667L14.6667 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+        )
       }
     </li>
     <li>
       {
-        previousPage 
-          ? <a href={previousPage} aria-label={`Go back to ${previousPage}`}><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m14 7-5 5 5 5"/></svg></a>
-          : <span class="disabled"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m14 7-5 5 5 5"/></svg></span>
+        previousPage ? (
+          <a href={previousPage} aria-label={`Go back to ${previousPage}`}>
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24">
+              <path
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m14 7-5 5 5 5"
+              />
+            </svg>
+          </a>
+        ) : (
+          <span class="disabled">
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24">
+              <path
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m14 7-5 5 5 5"
+              />
+            </svg>
+          </span>
+        )
       }
     </li>
     <li>
@@ -30,16 +104,90 @@ const {
     </li>
     <li>
       {
-        nextPage
-          ? <a href={nextPage} aria-label={`Go to ${nextPage}`}><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m10 7 5 5-5 5"/></svg></a>
-          : <span class="disabled"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m10 7 5 5-5 5"/></svg></span>
+        nextPage ? (
+          <a href={nextPage} aria-label={`Go to ${nextPage}`}>
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24">
+              <path
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m10 7 5 5-5 5"
+              />
+            </svg>
+          </a>
+        ) : (
+          <span class="disabled">
+            <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24">
+              <path
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="m10 7 5 5-5 5"
+              />
+            </svg>
+          </span>
+        )
       }
     </li>
     <li>
       {
-        lastPage
-          ? <a href={lastPage} aria-label="Go to the last page"><svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.33333 9L14 15.6667L7.33333 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/><path d="M17.3333 9L24 15.6667L17.3333 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
-          : <span class="disabled"><svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.33333 9L14 15.6667L7.33333 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/><path d="M17.3333 9L24 15.6667L17.3333 22.3333" stroke="currentColor" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+        lastPage ? (
+          <a href={lastPage} aria-label="Go to the last page">
+            <svg
+              aria-hidden="true"
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.33333 9L14 15.6667L7.33333 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M17.3333 9L24 15.6667L17.3333 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </a>
+        ) : (
+          <span class="disabled">
+            <svg
+              aria-hidden="true"
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.33333 9L14 15.6667L7.33333 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M17.3333 9L24 15.6667L17.3333 22.3333"
+                stroke="currentColor"
+                stroke-width="2.66667"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+        )
       }
     </li>
   </ul>

--- a/Pagination.astro
+++ b/Pagination.astro
@@ -1,4 +1,17 @@
 ---
+// Pagination Props type helpers
+export type NumericalString = `${number}`
+export type RouteString = string | null | undefined
+
+interface Props {
+  firstPage?: RouteString
+  previousPage?: RouteString
+  nextPage?: RouteString
+  lastPage?: RouteString
+  currentPage?: string | number
+  totalPages?: NumericalString | number
+}
+
 const {
   firstPage = '#',
   previousPage = '#',

--- a/SkipLinks.astro
+++ b/SkipLinks.astro
@@ -1,3 +1,7 @@
+---
+type Props = Record<string, never>
+---
+
 <div class="skip-links">
   <a href="#main-content">Skip to main content</a>
 </div>

--- a/SkipLinks.astro
+++ b/SkipLinks.astro
@@ -7,7 +7,7 @@
   const skipLink = document.querySelector('.skip-links a')
 
   // execution
-  skipLink.addEventListener('keydown', event => {
+  skipLink.addEventListener('keydown', (event) => {
     if (!event.target.closest('a')) return
     const key = event.key
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,514 @@
+{
+  "name": "accessible-astro-components",
+  "version": "1.6.5",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "accessible-astro-components",
+      "version": "1.6.5",
+      "license": "MIT",
+      "devDependencies": {
+        "prettier": "2.8.7",
+        "prettier-plugin-astro": "^0.8.0"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.3.0.tgz",
+      "integrity": "sha512-VxSj3gh/UTB/27rkRCT7SvyGjWtuxUO7Jf7QqDduch7j/gr/uA5P/Q5I/4zIIrZjy2yQAKyKLoox2QI2mM/BSA==",
+      "dev": true
+    },
+    "node_modules/@pkgr/utils": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "is-glob": "^4.0.3",
+        "open": "^8.4.0",
+        "picocolors": "^1.0.0",
+        "tiny-glob": "^0.2.9",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.8.0.tgz",
+      "integrity": "sha512-kt9wk33J7HvFGwFaHb8piwy4zbUmabC8Nu+qCw493jhe96YkpjscqGBPy4nJ9TPy9pd7+kEx1zM81rp+MIdrXg==",
+      "dev": true,
+      "dependencies": {
+        "@astrojs/compiler": "^1.0.1",
+        "prettier": "^2.8.3",
+        "sass-formatter": "^0.7.5",
+        "synckit": "^0.8.4"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0",
+        "pnpm": ">=7.14.0"
+      }
+    },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.6.tgz",
+      "integrity": "sha512-hXdxU6PCkiV3XAiSnX+XLqz2ohHoEnVUlrd8LEVMAI80uB1+OTScIkH9n6qQwImZpTye1r1WG1rbGUteHNhoHg==",
+      "dev": true,
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "dependencies": {
+        "s.color": "0.0.15"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
+  "dependencies": {
+    "@astrojs/compiler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.3.0.tgz",
+      "integrity": "sha512-VxSj3gh/UTB/27rkRCT7SvyGjWtuxUO7Jf7QqDduch7j/gr/uA5P/Q5I/4zIIrZjy2yQAKyKLoox2QI2mM/BSA==",
+      "dev": true
+    },
+    "@pkgr/utils": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "is-glob": "^4.0.3",
+        "open": "^8.4.0",
+        "picocolors": "^1.0.0",
+        "tiny-glob": "^0.2.9",
+        "tslib": "^2.4.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+          "dev": true
+        }
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+          "dev": true
+        }
+      }
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true
+    },
+    "prettier-plugin-astro": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.8.0.tgz",
+      "integrity": "sha512-kt9wk33J7HvFGwFaHb8piwy4zbUmabC8Nu+qCw493jhe96YkpjscqGBPy4nJ9TPy9pd7+kEx1zM81rp+MIdrXg==",
+      "dev": true,
+      "requires": {
+        "@astrojs/compiler": "^1.0.1",
+        "prettier": "^2.8.3",
+        "sass-formatter": "^0.7.5",
+        "synckit": "^0.8.4"
+      }
+    },
+    "s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true
+    },
+    "sass-formatter": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.6.tgz",
+      "integrity": "sha512-hXdxU6PCkiV3XAiSnX+XLqz2ohHoEnVUlrd8LEVMAI80uB1+OTScIkH9n6qQwImZpTye1r1WG1rbGUteHNhoHg==",
+      "dev": true,
+      "requires": {
+        "suf-log": "^2.5.3"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "requires": {
+        "s.color": "0.0.15"
+      }
+    },
+    "synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "homepage": "https://accessible-astro.dev",
   "type": "module",
   "exports": "./index.js",
+  "main": "./index.js",
+  "types": "./types",
   "keywords": [
     "astro",
     "astro-component",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "bugs": {
     "url": "https://github.com/markteekman/accessible-astro-components/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "prettier": "2.8.7",
+    "prettier-plugin-astro": "^0.8.0"
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,133 @@
+/**
+ * Accordion Item child component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.header - `<H3>` header text content
+ * @param _props.children - any HTML element/s, Parent element: `<div>`
+ */
+export type AccordionItem = typeof import('./AccordionItem.astro').default
+export const AccordionItem: AccordionItem
+
+/**
+ * Accordion Parent component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.children -
+ *  - Expects one or more AccordionItem components, Parent Element: `<ul>`
+ *  - WARNING: Astro cannot currently enforce the type of children in a Slot)
+ */
+type Accordion = typeof import('./Accordion.astro').default
+export const Accordion: Accordion
+
+/**
+ * Breadcrumbs item child component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.href - `<a href={href}>` Breadcrumb route string such as "/" or "/blog" - default: "#"
+ * @param _props.label - `<a>` text content for descriptive route name
+ * @param _props.currentPage - Boolean: isCurrentPage?
+ */
+export type BreadcrumbsItem = typeof import('./BreadcrumbsItem.astro').default
+export const BreadcrumbsItem: BreadcrumbsItem
+
+/**
+ * Breadcrumbs Parent component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.children -
+ *  - Expects one or more BreadcrumbsItem components, Parent Element: `<ol>`
+ *  - WARNING: Astro cannot currently enforce the type of children in a Slot)
+ */
+type Breadcrumbs = typeof import('./Breadcrumbs.astro').default
+export const Breadcrumbs: Breadcrumbs
+
+/**
+ * Card component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.url - `<a href={url}>` - default: "#"
+ * @param _props.img - `<img src={img}>` - default value = placeholder
+ * @param _props.title - `<H3>` header > `<a>` text content
+ * @param _props.footer - `<small>` text content
+ * @param _props.children - textContent or any legal P tag innerHtml such as inline HTML elements, Parent Element: `<p>`
+ */
+type Card = typeof import('./Card.astro').default
+export const Card: Card
+
+/**
+ * DorkMode toggle component
+ * - toggles class `darkmode` on `document.body`
+*
+* @param _props - Record<string, never>
+* ```
+* <style>
+ body.darkmode {
+   // define your dark color scheme here
+ }
+</style>
+```
+ */
+type DarkMode = typeof import('./DarkMode.astro').default
+export const DarkMode: DarkMode
+
+/**
+ * Media component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.class - string of one or more css class names
+ * @param _props.src - `<img src={src}>` - default: placeholder
+ * @param _props.alt - `<img alt={alt}>` required for non-decorative images
+ */
+type Media = typeof import('./Media.astro').default
+export const Media: Media
+
+/**
+ * Modal component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.title - `<H3>` header text content
+ * @param _props.closeText - `<button>` text content - default: "Close"
+ * @param _props.children - any HTML element/s, Parent element: `<div>`
+ */
+type Modal = typeof import('./Modal.astro').default
+export const Modal: Modal
+
+/**
+ * Notification component
+ *
+ * @param _props - Record<string, any>
+ * @param _props.type - Specifies background colore: info = blue, success = green, warning = yellow, error = red - default: browser default color
+ * @param _props.role - type of aria role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' -  default: 'none'
+ * @param _props.ariaLive -
+ * - Defines urgency of live announcements, when used prefer 'polite'
+ * - Warning: Because an interruption may disorient users or cause them to not complete their current task,
+ *   don't use the assertive value unless the interruption is imperative.
+ * @param _props.children - any HTML element/s, Parent element: `<div>`
+ */
+type Notification = typeof import('./Notification.astro').default
+export const Notification: Notification
+
+/**
+ * Pagination component
+ * @type `NumericalString` `` `${number}` ``
+ * @type `RouteString` `string | null | undefined`
+ * @param _props - Record<string, any>
+ * @param _props.firstPage - Falsy value = disabled link icon | `<a href={firstPage}>` route string such as "/" or "/blog" - default: "#"
+ * @param _props.previousPage - Falsy value = disabled link icon | `<a href={previousPage}>` route string such as "/" or "/blog/5" - default: "#"
+ * @param _props.nextPage - Falsy value = disabled link icon | `<a href={nextPage}>` route string such "/blog/2" - default: "#"
+ * @param _props.lastPage - Falsy value = disabled link icon | `<a href={lastPage}>` route string such "/blog/20" - default: "#"
+ * @param _props.currentPage - `<span>Page {currentPage} of {totalPages}</span>` - Default: '1'
+ * @param _props.totalPages - `<span>Page {currentPage} of {totalPages}</span>` - Default: '12
+ */
+type Pagination = typeof import('./Pagination.astro').default
+export const Pagination: Pagination
+
+/**
+ * Skip link component
+ * - Expects either `#id=#main-content` or`<h1>` to be in document
+ *
+ * @param _props - Record<string, never>
+ *
+ */
+type SkipLinks = typeof import('./SkipLinks.astro').default
+export const SkipLinks: SkipLinks

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,20 +1,20 @@
 /**
- * Accordion Item child component
+ * Accordion item child component
  *
  * @param _props - Record<string, any>
- * @param _props.header - `<H3>` header text content
- * @param _props.children - any HTML element/s, Parent element: `<div>`
+ * @param _props.header - `<h3>` header text content
+ * @param _props.children - Any HTML elements. Parent element: `<div>`
  */
 export type AccordionItem = typeof import('./AccordionItem.astro').default
 export const AccordionItem: AccordionItem
 
 /**
- * Accordion Parent component
+ * Accordion parent component
  *
  * @param _props - Record<string, any>
  * @param _props.children -
- *  - Expects one or more AccordionItem components, Parent Element: `<ul>`
- *  - WARNING: Astro cannot currently enforce the type of children in a Slot)
+ *  - Expects one or more AccordionItem components. Parent element: `<ul>`
+ *  - WARNING: Astro cannot currently enforce the type of children in a `<slot>`
  */
 type Accordion = typeof import('./Accordion.astro').default
 export const Accordion: Accordion
@@ -31,12 +31,12 @@ export type BreadcrumbsItem = typeof import('./BreadcrumbsItem.astro').default
 export const BreadcrumbsItem: BreadcrumbsItem
 
 /**
- * Breadcrumbs Parent component
+ * Breadcrumbs parent component
  *
  * @param _props - Record<string, any>
  * @param _props.children -
- *  - Expects one or more BreadcrumbsItem components, Parent Element: `<ol>`
- *  - WARNING: Astro cannot currently enforce the type of children in a Slot)
+ *  - Expects one or more BreadcrumbsItem components. Parent element: `<ol>`
+ *  - WARNING: Astro cannot currently enforce the type of children in a `<slot>`
  */
 type Breadcrumbs = typeof import('./Breadcrumbs.astro').default
 export const Breadcrumbs: Breadcrumbs
@@ -47,16 +47,16 @@ export const Breadcrumbs: Breadcrumbs
  * @param _props - Record<string, any>
  * @param _props.url - `<a href={url}>` - default: "#"
  * @param _props.img - `<img src={img}>` - default value = placeholder
- * @param _props.title - `<H3>` header > `<a>` text content
+ * @param _props.title - `<h3>` header > `<a>` text content
  * @param _props.footer - `<small>` text content
- * @param _props.children - textContent or any legal P tag innerHtml such as inline HTML elements, Parent Element: `<p>`
+ * @param _props.children - textContent or any legal `<p>` tag innerHTML such as inline HTML elements. Parent element: `<p>`
  */
 type Card = typeof import('./Card.astro').default
 export const Card: Card
 
 /**
- * DorkMode toggle component
- * - toggles class `darkmode` on `document.body`
+ * DarkMode toggle component
+ * - Toggles class `darkmode` on `document.body`
 *
 * @param _props - Record<string, never>
 * ```
@@ -74,7 +74,7 @@ export const DarkMode: DarkMode
  * Media component
  *
  * @param _props - Record<string, any>
- * @param _props.class - string of one or more css class names
+ * @param _props.class - String of one or more CSS class names
  * @param _props.src - `<img src={src}>` - default: placeholder
  * @param _props.alt - `<img alt={alt}>` required for non-decorative images
  */
@@ -85,9 +85,9 @@ export const Media: Media
  * Modal component
  *
  * @param _props - Record<string, any>
- * @param _props.title - `<H3>` header text content
+ * @param _props.title - `<h3>` header text content
  * @param _props.closeText - `<button>` text content - default: "Close"
- * @param _props.children - any HTML element/s, Parent element: `<div>`
+ * @param _props.children - Any HTML elements. Parent element: `<div>`
  */
 type Modal = typeof import('./Modal.astro').default
 export const Modal: Modal
@@ -96,13 +96,13 @@ export const Modal: Modal
  * Notification component
  *
  * @param _props - Record<string, any>
- * @param _props.type - Specifies background colore: info = blue, success = green, warning = yellow, error = red - default: browser default color
- * @param _props.role - type of aria role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' -  default: 'none'
+ * @param _props.type - Specifies background color: info = blue, success = green, warning = yellow, error = red - default: browser default color
+ * @param _props.role - Type of aria role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' -  default: 'none'
  * @param _props.ariaLive -
  * - Defines urgency of live announcements, when used prefer 'polite'
  * - Warning: Because an interruption may disorient users or cause them to not complete their current task,
  *   don't use the assertive value unless the interruption is imperative.
- * @param _props.children - any HTML element/s, Parent element: `<div>`
+ * @param _props.children - any HTML elements. Parent element: `<div>`
  */
 type Notification = typeof import('./Notification.astro').default
 export const Notification: Notification

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Describe your changes

 - Add dev dependencies: Prettier, prettier-plugin-astro for `*.astro` file support, and `.prettierrc` for config.
 - Format components with Prettier configs, removed extraneous empty path tags `<>` from formatting.
 - Add Typescript declaration and component Props types.

## Issue ticket number and link

Issue #40 

## Checklist before requesting a review
- [X] I have performed a self-review of my code

## Specific areas needing review

- `Notification.astro`: I've based the `role` prop off MDN accessibility requirements but I'm not an accessibility expert so I would appreciate these being double checked for accuracy. Left in a comment that region could possibly be added as a role but there is no ID currently on the component. If I'm correct and this is easy to add this way, I figured it might be better suited to a separate pull request.

- `Pagination.astro`: Astro.props default values such as `firstPage = '#',` appear to be purely descriptive. It might be worth removing these in favor of the type declarations so that users do not need to explicitly pass falsy values.

  `Pagination.astro` SVG formatting was also heavily impacted by Prettier. `.prettierrc`. config changes may or may not be desired.

- `index.d.ts`: It would be good to have a second set of eyes on `@param` descriptions to check for accuracy and legibility.

