### PR TITLE
Fix: multiple modals on a single page, resolves #39

### DIFF
--- a/Modal.astro
+++ b/Modal.astro
@@ -23,13 +23,14 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
   </div>
 </div>
 
-<script type="module">
+<script>
   // variables
   const body = document.querySelector('body')
-  const modal = document.querySelector('.modal')
-  const modalId = modal.getAttribute('aria-labelledby')
-  const modalCloseButton = modal.querySelector('.modal__close button')
-  const modalTrigger = document.querySelector(`#${modalId}`)
+  const modals = new Set()
+
+  // abort controllers for global event listeners
+  let trapFocusController
+  let keydownController
 
   // functions
   const teleportToRoot = (element) => {
@@ -43,7 +44,7 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     ].filter((el) => !el.hasAttribute('disabled'))
   }
 
-  const trapFocus = (event) => {
+  const trapFocus = (event, modal) => {
     const focusables = getKeyboardFocusableElements(modal)
     const firstFocusable = focusables[0]
     const lastFocusable = focusables[focusables.length - 1]
@@ -59,40 +60,66 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     }
   }
 
-  const openModal = (_) => {
+  const openModal = (modal) => {
     const modalTitle = modal.querySelector('h3')
 
     modal.classList.add('show')
     body.classList.add('modal-is-active')
     modalTitle.focus()
-    document.addEventListener('keydown', trapFocus)
 
-    modal.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') {
-        closeModal()
-      }
-    })
+    trapFocusController = new AbortController()
+    keydownController = new AbortController()
+
+    document.addEventListener('keydown', (e) => trapFocus(e, modal), { signal: trapFocusController.signal })
+
+    modal.addEventListener(
+      'keydown',
+      (event) => {
+        if (event.key === 'Escape') {
+          closeModal()
+        }
+      },
+      { signal: keydownController.signal }
+    )
   }
 
   const closeModal = (_) => {
-    modal.classList.remove('show')
+    modals.forEach((modal) => {
+      modal.classList.remove('show')
+      const modalId = modal.getAttribute('aria-labelledby')
+      const modalTrigger = document.querySelector(`#${modalId}`)
+      modalTrigger.focus({ preventScroll: true })
+      trapFocusController.abort()
+      keydownController.abort()
+    })
     body.classList.remove('modal-is-active')
-    modalTrigger.focus({ preventScroll: true })
-    document.removeEventListener('keydown', trapFocus)
+  }
+
+  const setModels = () => {
+    const modalNodes = document.querySelectorAll('.modal')
+
+    modalNodes.forEach((node) => {
+      const modalId = node.getAttribute('aria-labelledby')
+      const modalCloseButton = node.querySelector('.modal__close button')
+      const modalTrigger = document.querySelector(`#${modalId}`)
+
+      modalTrigger.addEventListener('click', () => openModal(node))
+      modalCloseButton.addEventListener('click', closeModal)
+
+      node.addEventListener('click', (event) => {
+        if (!event.target.closest('.modal__content')) {
+          closeModal()
+        }
+      })
+
+      modals.add(node)
+    })
   }
 
   // execution
-  teleportToRoot(modal)
+  setModels()
 
-  modalTrigger.addEventListener('click', openModal)
-
-  modalCloseButton.addEventListener('click', closeModal)
-
-  modal.addEventListener('click', (event) => {
-    if (!event.target.closest('.modal__content')) {
-      closeModal()
-    }
-  })
+  modals.forEach((modal) => teleportToRoot(modal))
 
   window.closeModal = closeModal
 </script>

--- a/Modal.astro
+++ b/Modal.astro
@@ -26,7 +26,7 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
 <script>
   // variables
   const body = document.querySelector('body')
-  const modals = new Set()
+  const modals = document.querySelectorAll('.modal')
 
   // abort controllers for global event listeners
   let trapFocusController
@@ -95,31 +95,23 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     body.classList.remove('modal-is-active')
   }
 
-  const setModels = () => {
-    const modalNodes = document.querySelectorAll('.modal')
-
-    modalNodes.forEach((node) => {
-      const modalId = node.getAttribute('aria-labelledby')
-      const modalCloseButton = node.querySelector('.modal__close button')
-      const modalTrigger = document.querySelector(`#${modalId}`)
-
-      modalTrigger.addEventListener('click', () => openModal(node))
-      modalCloseButton.addEventListener('click', closeModal)
-
-      node.addEventListener('click', (event) => {
-        if (!event.target.closest('.modal__content')) {
-          closeModal()
-        }
-      })
-
-      modals.add(node)
-    })
-  }
-
   // execution
-  setModels()
+  modals.forEach((modal) => {
+    const modalId = modal.getAttribute('aria-labelledby')
+    const modalCloseButton = modal.querySelector('.modal__close button')
+    const modalTrigger = document.querySelector(`#${modalId}`)
 
-  modals.forEach((modal) => teleportToRoot(modal))
+    modalTrigger.addEventListener('click', () => openModal(modal))
+    modalCloseButton.addEventListener('click', closeModal)
+
+    modal.addEventListener('click', (event) => {
+      if (!event.target.closest('.modal__content')) {
+        closeModal()
+      }
+    })
+
+    teleportToRoot(modal)
+  })
 
   window.closeModal = closeModal
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessible-astro-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessible-astro-components",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessible-astro-components",
-  "version": "1.6.5",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessible-astro-components",
-      "version": "1.6.5",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessible-astro-components",
   "description": "A set of Accessible, easy to use, Front-end UI Components for Astro.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Mark Teekman",
   "homepage": "https://accessible-astro.netlify.app/accessible-components/",
   "type": "module",


### PR DESCRIPTION
A bug in astro-compress (introduced sometime after [v1.1.28](https://github.com/astro-community/astro-compress/releases/tag/v1.1.28)) incorrectly ships empty script files for the Modal component when running astro build.

In-lining the scripts as Astro recommends with `<script is:inline>` resolves the empty script tags but still does not handle multiple modals.

This pull request, basically the same as @mciszczon wrote with added abort controllers for the global listeners, makes the script global and switches to a collection of modals. This allows multiple modals on a page and ships less script tags while doing so.

Tested with astro-accessible-starter and the latest version of astro-compress [v1.1.42](https://github.com/astro-community/astro-compress/releases/tag/v1.1.42)