### PR TITLE
fix: expand package.json exports to object containing types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "author": "Mark Teekman",
   "homepage": "https://accessible-astro.netlify.app/accessible-components/",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./index.js"
+      }
+    }
+  },
   "main": "./index.js",
-  "types": "./types",
+  "types": "./types/index.d.ts",
   "keywords": [
     "astro",
     "astro-component",


### PR DESCRIPTION
Fixes #51.

Essentially copies @david-abell's https://github.com/markteekman/accessible-astro-components/issues/51#issuecomment-1674651757, so adding a co-author attribution. Thanks for the pointer!

Co-authored-by: @david-abell