### PR TITLE
Modal refactor resolves #48

### DIFF
--- a/Media.astro
+++ b/Media.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  class: string
+  class?: string
   src?: string
   alt?: string
 }

--- a/Modal.astro
+++ b/Modal.astro
@@ -9,7 +9,7 @@ interface Props {
 const { triggerId, title, closeText = 'Close' } = Astro.props
 ---
 
-<div class="modal" role="dialog" aria-labelledby={triggerId}>
+<dialog class="modal" role="dialog" aria-labelledby={triggerId}>
   <div class="modal__inner">
     <div class="modal__content">
       <h3 tabindex="-1">
@@ -21,33 +21,38 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
       <button>{closeText}</button>
     </div>
   </div>
-</div>
+</dialog>
 
 <script>
+  type FocusableElement =
+    | HTMLAnchorElement
+    | HTMLButtonElement
+    | HTMLInputElement
+    | HTMLTextAreaElement
+    | HTMLSelectElement
+    | HTMLDetailsElement
+
   // variables
-  const body = document.querySelector('body')
-  const modals = document.querySelectorAll('.modal')
+  const modals = document.querySelectorAll<HTMLDialogElement>('.modal')
 
   // abort controllers for global event listeners
-  let trapFocusController
-  let keydownController
+  let trapFocusController: AbortController | undefined
+  let keydownController: AbortController | undefined
 
-  // functions
-  const teleportToRoot = (element) => {
-    element.remove()
-    body.appendChild(element)
-  }
-
-  const getKeyboardFocusableElements = (element) => {
+  const getKeyboardFocusableElements = (element: HTMLElement) => {
     return [
-      ...element.querySelectorAll('a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'),
+      ...element.querySelectorAll<FocusableElement>(
+        'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+      ),
     ].filter((el) => !el.hasAttribute('disabled'))
   }
 
-  const trapFocus = (event, modal) => {
+  const trapFocus = (event: KeyboardEvent, modal: HTMLDialogElement) => {
     const focusables = getKeyboardFocusableElements(modal)
-    const firstFocusable = focusables[0]
-    const lastFocusable = focusables[focusables.length - 1]
+
+    // These will not be undefined as a modal always has at least one <button>
+    const firstFocusable = focusables[0]!
+    const lastFocusable = focusables[focusables.length - 1]!
 
     if (document.activeElement === lastFocusable && event.key === 'Tab' && !event.shiftKey) {
       event.preventDefault()
@@ -60,12 +65,12 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     }
   }
 
-  const openModal = (modal) => {
+  const openModal = (modal: HTMLDialogElement) => {
     const modalTitle = modal.querySelector('h3')
+    const modalInner = modal.querySelector<HTMLDivElement>('.modal__inner')
 
-    modal.classList.add('show')
-    body.classList.add('modal-is-active')
-    modalTitle.focus()
+    modal.showModal()
+    modalTitle!.focus()
 
     trapFocusController = new AbortController()
     keydownController = new AbortController()
@@ -81,18 +86,33 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
       },
       { signal: keydownController.signal }
     )
+
+    modal.addEventListener(
+      'click',
+      () => {
+        closeModal()
+      },
+      { signal: keydownController.signal }
+    )
+
+    modalInner!.addEventListener(
+      'click',
+      (event) => {
+        event.stopPropagation()
+      },
+      { signal: keydownController.signal }
+    )
   }
 
-  const closeModal = (_) => {
+  const closeModal = () => {
     modals.forEach((modal) => {
-      modal.classList.remove('show')
       const modalId = modal.getAttribute('aria-labelledby')
-      const modalTrigger = document.querySelector(`#${modalId}`)
+      const modalTrigger = document.querySelector(`#${modalId}`) as HTMLButtonElement
       modalTrigger.focus({ preventScroll: true })
-      trapFocusController.abort()
-      keydownController.abort()
+      modal.close()
+      trapFocusController?.abort()
+      keydownController?.abort()
     })
-    body.classList.remove('modal-is-active')
   }
 
   // execution
@@ -101,44 +121,33 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     const modalCloseButton = modal.querySelector('.modal__close button')
     const modalTrigger = document.querySelector(`#${modalId}`)
 
+    if (!modalTrigger) {
+      throw new Error(`Trigger element not found. \n
+      Did you forget to add a trigger element with id: "${modalId}"?`)
+    }
+
     modalTrigger.addEventListener('click', () => openModal(modal))
-    modalCloseButton.addEventListener('click', closeModal)
-
-    modal.addEventListener('click', (event) => {
-      if (!event.target.closest('.modal__content')) {
-        closeModal()
-      }
-    })
-
-    teleportToRoot(modal)
+    modalCloseButton!.addEventListener('click', closeModal)
   })
 
   window.closeModal = closeModal
 </script>
 
 <style is:global>
-  body.modal-is-active > *:not(.modal) {
+  dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.5);
     filter: blur(6px);
   }
 
   .modal {
-    height: 0;
-    position: fixed;
-    visibility: hidden;
-    z-index: -10;
+    color: black;
+    background-color: white;
+    border: 0.5rem solid black;
+    border-radius: 1rem;
+    padding: 0;
   }
 
-  .modal.show {
-    display: grid;
-    place-items: center;
-    visibility: visible;
-    height: auto;
-    background-color: rgba(0, 0, 0, 0.5);
-    inset: 0;
-    z-index: 10;
-  }
-
-  .modal.show .modal__inner {
+  .modal .modal__inner {
     opacity: 1;
   }
 
@@ -146,10 +155,14 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     width: clamp(30ch, 70%, 75ch);
     color: black;
     background-color: white;
-    border: 0.5rem solid black;
     border-radius: 1rem;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
+  }
+
+  .modal__inner {
+    width: 100%;
+    height: 100%;
   }
 
   .modal__content {
@@ -160,14 +173,20 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     padding: 2rem;
   }
 
-  .modal__close button {
+  .modal__close {
     width: 100%;
+  }
+
+  .modal__close button {
     border: none;
     background-color: lightgrey;
     border-bottom-left-radius: 0.4rem;
     border-bottom-right-radius: 0.4rem;
     text-align: right;
     transition: background-color 0.15s ease-in-out;
+    width: 100%;
+    margin: 0;
+    padding: 0.5rem;
   }
 
   .modal__close button:hover,

--- a/Notification.astro
+++ b/Notification.astro
@@ -1,8 +1,7 @@
 ---
 interface Props {
-  // role="region" not supported as element takes no id
   type?: 'info' | 'success' | 'warning' | 'error' | 'default'
-  role?: 'none' | 'alert' | 'log' | 'marquee' | 'status' | 'timer'
+  role?: 'none' | 'alert' | 'log' | 'marquee' | 'status' | 'timer' | 'region'
   ariaLive?: 'off' | 'polite' | 'assertive'
   children?: any
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/strictest",
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "allowJs": true,
+    "rootDir": "."
+    // "skipLibCheck": true
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@
  * @param _props.header - `<h3>` header text content
  * @param _props.children - Any HTML elements. Parent element: `<div>`
  */
-export type AccordionItem = typeof import('./AccordionItem.astro').default
+export type AccordionItem = typeof import('../index.js').AccordionItem
 export const AccordionItem: AccordionItem
 
 /**
@@ -16,7 +16,7 @@ export const AccordionItem: AccordionItem
  *  - Expects one or more AccordionItem components. Parent element: `<ul>`
  *  - WARNING: Astro cannot currently enforce the type of children in a `<slot>`
  */
-type Accordion = typeof import('./Accordion.astro').default
+type Accordion = typeof import('../index.js').Accordion
 export const Accordion: Accordion
 
 /**
@@ -27,7 +27,7 @@ export const Accordion: Accordion
  * @param _props.label - `<a>` text content for descriptive route name
  * @param _props.currentPage - Boolean: isCurrentPage?
  */
-export type BreadcrumbsItem = typeof import('./BreadcrumbsItem.astro').default
+export type BreadcrumbsItem = typeof import('../index.js').BreadcrumbsItem
 export const BreadcrumbsItem: BreadcrumbsItem
 
 /**
@@ -38,7 +38,7 @@ export const BreadcrumbsItem: BreadcrumbsItem
  *  - Expects one or more BreadcrumbsItem components. Parent element: `<ol>`
  *  - WARNING: Astro cannot currently enforce the type of children in a `<slot>`
  */
-type Breadcrumbs = typeof import('./Breadcrumbs.astro').default
+type Breadcrumbs = typeof import('../index.js').Breadcrumbs
 export const Breadcrumbs: Breadcrumbs
 
 /**
@@ -51,7 +51,7 @@ export const Breadcrumbs: Breadcrumbs
  * @param _props.footer - `<small>` text content
  * @param _props.children - textContent or any legal `<p>` tag innerHTML such as inline HTML elements. Parent element: `<p>`
  */
-type Card = typeof import('./Card.astro').default
+type Card = typeof import('../index.js').Card
 export const Card: Card
 
 /**
@@ -67,7 +67,7 @@ export const Card: Card
 </style>
 ```
  */
-type DarkMode = typeof import('./DarkMode.astro').default
+type DarkMode = typeof import('../index.js').DarkMode
 export const DarkMode: DarkMode
 
 /**
@@ -78,7 +78,7 @@ export const DarkMode: DarkMode
  * @param _props.src - `<img src={src}>` - default: placeholder
  * @param _props.alt - `<img alt={alt}>` required for non-decorative images
  */
-type Media = typeof import('./Media.astro').default
+export type Media = typeof import('../index.js').Media
 export const Media: Media
 
 /**
@@ -89,7 +89,7 @@ export const Media: Media
  * @param _props.closeText - `<button>` text content - default: "Close"
  * @param _props.children - Any HTML elements. Parent element: `<div>`
  */
-type Modal = typeof import('./Modal.astro').default
+type Modal = typeof import('../index.js').Modal
 export const Modal: Modal
 
 /**
@@ -97,14 +97,14 @@ export const Modal: Modal
  *
  * @param _props - Record<string, any>
  * @param _props.type - Specifies background color: info = blue, success = green, warning = yellow, error = red - default: browser default color
- * @param _props.role - Type of aria role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' -  default: 'none'
+ * @param _props.role - Type of aria role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' | 'region' -  default: 'none'
  * @param _props.ariaLive -
  * - Defines urgency of live announcements, when used prefer 'polite'
  * - Warning: Because an interruption may disorient users or cause them to not complete their current task,
  *   don't use the assertive value unless the interruption is imperative.
  * @param _props.children - any HTML elements. Parent element: `<div>`
  */
-type Notification = typeof import('./Notification.astro').default
+type Notification = typeof import('../index.js').Notification
 export const Notification: Notification
 
 /**
@@ -119,7 +119,7 @@ export const Notification: Notification
  * @param _props.currentPage - `<span>Page {currentPage} of {totalPages}</span>` - Default: '1'
  * @param _props.totalPages - `<span>Page {currentPage} of {totalPages}</span>` - Default: '12
  */
-type Pagination = typeof import('./Pagination.astro').default
+type Pagination = typeof import('../index.js').Pagination
 export const Pagination: Pagination
 
 /**
@@ -129,5 +129,5 @@ export const Pagination: Pagination
  * @param _props - Record<string, never>
  *
  */
-type SkipLinks = typeof import('./SkipLinks.astro').default
+type SkipLinks = typeof import('../index.js').SkipLinks
 export const SkipLinks: SkipLinks

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,6 +93,15 @@ type Modal = typeof import('../index.js').Modal
 export const Modal: Modal
 
 /**
+ * Global closeModal function for Modal component
+ */
+declare global {
+  interface Window {
+    closeModal: () => void
+  }
+}
+
+/**
  * Notification component
  *
  * @param _props - Record<string, any>

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "skipLibCheck": true
-  }
-}


### PR DESCRIPTION
This pull request refactors the Modal component to use the HTML Dialog Element.

Most of the business logic was reusable. Teleport to root and active/not active classes were not needed.

Text to speech with NVDA appears to match behavior of prior component.

:heavy_check_mark: Button that triggers the dialog still needs to be linked to the Modal.
:heavy_check_mark: Clicking on the backdrop should close the Modal.
:heavy_check_mark: Keyboard trap tested with additional button and textarea as part of <slot> content
:heavy_check_mark: Pressing `escape` closes open dialogs as before.
