### PR TITLE
fix: default src value not a placeholder

### DIFF
--- a/Media.astro
+++ b/Media.astro
@@ -5,7 +5,7 @@ interface Props {
   alt?: string
 }
 
-const { class: classNames, src = 'https://shorturl.at/tCPS2', alt = '' } = Astro.props
+const { class: classNames, src = 'https://fakeimg.pl/640x360', alt = '' } = Astro.props
 ---
 
 <img class={classNames} src={src} alt={alt} loading="lazy" decoding="async" />


### PR DESCRIPTION
I found while working on the modal refactor that the Media component's src attribute default value is a facebook url and not a placeholder image. Looks like a clipboard error. This pull request replaces the value with the same fake image src used by the Card component.