### PR TITLE
Support view transitions for dark mode toggle & Modal

### DIFF
--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -56,7 +56,6 @@ darkModeToggle.addEventListener('click', () => {
 document.addEventListener('astro:after-swap', () => {
   // Setup
   darkMode = localStorage.getItem('darkMode')
-  console.log({ darkModeToggle })
 
   // Execution
   if (darkMode === 'enabled') enableDarkMode()

--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -2,7 +2,7 @@
 type Props = Record<string, never>
 ---
 
-<button class="darkmode-toggle" aria-pressed="false" aria-label="Enable dark mode">
+<button class="darkmode-toggle" aria-pressed="false" aria-label="Enable dark mode" transition:persist>
   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"
     ><path
       fill="currentColor"
@@ -50,5 +50,17 @@ darkModeToggle.addEventListener('click', () => {
   darkMode = document.body.classList.contains('darkmode')
 
   !darkMode ? enableDarkMode() : disableDarkMode()
+})
+
+// Listen for view transitions
+document.addEventListener('astro:after-swap', () => {
+  // Setup
+  darkMode = localStorage.getItem('darkMode')
+  console.log({ darkModeToggle })
+
+  // Execution
+  if (darkMode === 'enabled') enableDarkMode()
+  if (darkMode === 'disabled') disableDarkMode()
+  if (!darkMode) checkPreference()
 })
 </script>

--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -12,44 +12,43 @@ type Props = Record<string, never>
 </button>
 
 <script is:inline>
-  // variables
-  let darkMode = localStorage.getItem('darkMode')
-  const darkModeToggle = document.querySelector('.darkmode-toggle')
+// variables
+let darkMode = localStorage.getItem('darkMode')
+const darkModeToggle = document.querySelector('.darkmode-toggle')
 
-  // functions
-  const enableDarkMode = (store = true) => {
-    document.body.classList.add('darkmode')
-    darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M13 3a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0V3zM5.707 4.293a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zm14 0a1 1 0 0 0-1.414 0l-1 1a1 1 0 0 0 1.414 1.414l1-1a1 1 0 0 0 0-1.414zM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm-9 4a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2H3zm17 0a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2h-1zM6.707 18.707a1 1 0 1 0-1.414-1.414l-1 1a1 1 0 1 0 1.414 1.414l1-1zm12-1.414a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zM13 20a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0v-1z" fill="currentColor"/></svg>`
-    darkModeToggle.setAttribute('aria-pressed', 'true')
-    darkModeToggle.setAttribute('aria-label', 'Disable dark mode')
-    if (store) localStorage.setItem('darkMode', 'enabled')
+// functions
+const enableDarkMode = (store = true) => {
+  document.body.classList.add('darkmode')
+  darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M13 3a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0V3zM5.707 4.293a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zm14 0a1 1 0 0 0-1.414 0l-1 1a1 1 0 0 0 1.414 1.414l1-1a1 1 0 0 0 0-1.414zM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm-9 4a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2H3zm17 0a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2h-1zM6.707 18.707a1 1 0 1 0-1.414-1.414l-1 1a1 1 0 1 0 1.414 1.414l1-1zm12-1.414a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zM13 20a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0v-1z" fill="currentColor"/></svg>`
+  darkModeToggle.setAttribute('aria-pressed', 'true')
+  darkModeToggle.setAttribute('aria-label', 'Disable dark mode')
+  if (store) localStorage.setItem('darkMode', 'enabled')
+}
+
+const disableDarkMode = (store = true) => {
+  document.body.classList.remove('darkmode')
+  darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M9.353 3C5.849 4.408 3 7.463 3 11.47A9.53 9.53 0 0 0 12.53 21c4.007 0 7.062-2.849 8.47-6.353C8.17 17.065 8.14 8.14 9.353 3z"/></svg>`
+  darkModeToggle.setAttribute('aria-pressed', 'false')
+  darkModeToggle.setAttribute('aria-label', 'Enable dark mode')
+  if (store) localStorage.setItem('darkMode', 'disabled')
+}
+
+const checkPreference = () => {
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    enableDarkMode(false) // don't set localStorage from preferences to respect future changes in client prefs
+  } else {
+    disableDarkMode(false)
   }
+}
 
-  const disableDarkMode = (store = true) => {
-    document.body.classList.remove('darkmode')
-    darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M9.353 3C5.849 4.408 3 7.463 3 11.47A9.53 9.53 0 0 0 12.53 21c4.007 0 7.062-2.849 8.47-6.353C8.17 17.065 8.14 8.14 9.353 3z"/></svg>`
-    darkModeToggle.setAttribute('aria-pressed', 'false')
-    darkModeToggle.setAttribute('aria-label', 'Enable dark mode')
-    if (store) localStorage.setItem('darkMode', 'disabled')
-  }
+// execution
+if (darkMode === 'enabled') enableDarkMode()
+if (darkMode === 'disabled') disableDarkMode()
+if (!darkMode) checkPreference()
 
-  const checkPreference = () => {
-    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      enableDarkMode(false);  // don't set localStorage from preferences to respect future changes in client prefs
-    } else {
-      disableDarkMode(false);
-    }
+darkModeToggle.addEventListener('click', () => {
+  darkMode = document.body.classList.contains('darkmode')
 
-  }
-
-  // execution
-  if (darkMode === 'enabled') enableDarkMode()
-  if (darkMode === 'disabled') disableDarkMode()
-  if (!darkMode) checkPreference()
-
-  darkModeToggle.addEventListener('click', () => {
-    darkMode = document.body.classList.contains('darkmode')
-
-    !darkMode ? enableDarkMode() : disableDarkMode()
-  })
+  !darkMode ? enableDarkMode() : disableDarkMode()
+})
 </script>

--- a/Modal.astro
+++ b/Modal.astro
@@ -33,7 +33,7 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
     | HTMLDetailsElement
 
   // variables
-  const modals = document.querySelectorAll<HTMLDialogElement>('.modal')
+  let modals = document.querySelectorAll<HTMLDialogElement>('.modal')
 
   // abort controllers for global event listeners
   let trapFocusController: AbortController | undefined
@@ -131,6 +131,27 @@ const { triggerId, title, closeText = 'Close' } = Astro.props
   })
 
   window.closeModal = closeModal
+
+  // Listen for view transitions
+  document.addEventListener('astro:after-swap', () => {
+    // reset variables
+    modals = document.querySelectorAll<HTMLDialogElement>('.modal')
+
+    // execution
+    modals.forEach((modal) => {
+      const modalId = modal.getAttribute('aria-labelledby')
+      const modalCloseButton = modal.querySelector('.modal__close button')
+      const modalTrigger = document.querySelector(`#${modalId}`)
+
+      if (!modalTrigger) {
+        throw new Error(`Trigger element not found. \n
+      Did you forget to add a trigger element with id: "${modalId}"?`)
+      }
+
+      modalTrigger.addEventListener('click', () => openModal(modal))
+      modalCloseButton!.addEventListener('click', closeModal)
+    })
+  })
 </script>
 
 <style is:global>

--- a/README.md
+++ b/README.md
@@ -309,9 +309,12 @@ You can apply your own styles by either setting the individual properties using 
 ```scss
 <style lang="scss" is:global>
   body {
+    .modal {
+        color: purple;
+        background-color: gold;
+      }
+
     .modal__inner {
-      color: purple;
-      background-color: gold;
       border-color: orange;
     }
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ You can apply your own styles by either setting the individual properties using 
     }
 
     .modal__close button {
+      color: white;
       background-color: blue;
 
       &:hover,


### PR DESCRIPTION
I've been playing around with the new [Sanity/Astro integration](https://www.sanity.io/plugins/sanity-astro#:~:text=complete%20implementation%20examples.-,Embedding%20Sanity%20Studio%20on%20a%20route,-Sanity%20Studio%20is) and the very cool new Astro 3 [viewTransitions api](https://docs.astro.build/en/guides/view-transitions/#full-site-view-transitions-spa-mode) that allows embeding a SPA inside a route.  

I noticed while doing so that the DarkMode toggle is broken with the new api.

 - Adding the `transition:persist` attribute to the top level `<button>` element keeps the variables and event listeners from disappearing. Incidentally this seems to also to be necessary for the accessible-astro-starter `has-dropdown` script logic...

 - `document.addEventListener('astro:after-swap', () => {}` runs after a page transition seems to be necessary to keep the `matchMedia('(prefers-color-scheme: dark)')` logic synced up.

Also, sorry for the major reformat on this one. Prettier seems to want to format inline scripts differently and for some reason that never happened before...I probably forgot the --write option when running `prettier .`  to format everything way back when :grimacing:.

Edit: Modals were also broken. I've added that component to this pull request.

` SkipLinks` and` Accordian` still work. Its possible this is because they are declared with `type="module"` which according to the docs inlines them with out bundling or preprocessing [see the note in the bundling section](https://docs.astro.build/en/guides/client-side-scripts/#script-bundling). That's all just a guess though, I haven't tested it.

