### PR TITLE
fix: card children can be a string

### DIFF
--- a/Card.astro
+++ b/Card.astro
@@ -4,7 +4,7 @@ interface Props {
   img?: string
   title?: string
   footer: string
-  children?: HTMLElement | HTMLElement[]
+  children?: string | HTMLElement | HTMLElement[]
 }
 
 const { url = '#', img = 'https://fakeimg.pl/640x360', title = 'Default title', footer = 'Your name' } = Astro.props


### PR DESCRIPTION
This is a small type definition bugfix that I mentioned in the modal updates pull request.

Since the card `<slot />` parent element is a `<p>` tag, it should accept a string as content and not just html elements.