### PR TITLE
Correct Aria / Markup for a current page in Breadcrumb Item

### DIFF
--- a/BreadcrumbsItem.astro
+++ b/BreadcrumbsItem.astro
@@ -9,7 +9,7 @@ const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
 ---
 
 <li class="breadcrumbs__item">
-  {currentPage ? <a href="" aria-current="page">{label}</a> : <a href={href}>{label}</a>}
+  {currentPage ? <span aria-current="page">{label}</span> : <a href={href}>{label}</a>}
 </li>
 
 <style is:global>
@@ -24,14 +24,5 @@ const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
 
   .breadcrumbs__item:last-child::after {
     content: '';
-  }
-
-  .breadcrumbs__item a[aria-current]:not([aria-current="false"]) {
-	color: var(--font-color);
-	text-decoration: none;
-  }
-
-  .breadcrumbs__item a[aria-current]:not([aria-current="false"]):hover {
-	color: var(--action-color-state);
   }
 </style>

--- a/BreadcrumbsItem.astro
+++ b/BreadcrumbsItem.astro
@@ -9,7 +9,7 @@ const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
 ---
 
 <li class="breadcrumbs__item">
-  {currentPage ? <span>{label}</span> : <a href={href}>{label}</a>}
+  {currentPage ? <a href="" aria-current="page">{label}</a> : <a href={href}>{label}</a>}
 </li>
 
 <style is:global>

--- a/BreadcrumbsItem.astro
+++ b/BreadcrumbsItem.astro
@@ -25,4 +25,13 @@ const { href = '#', label = 'Breadcrumb', currentPage = false } = Astro.props
   .breadcrumbs__item:last-child::after {
     content: '';
   }
+
+  .breadcrumbs__item a[aria-current]:not([aria-current="false"]) {
+	color: var(--font-color);
+	text-decoration: none;
+  }
+
+  .breadcrumbs__item a[aria-current]:not([aria-current="false"]):hover {
+	color: var(--action-color-state);
+  }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessible-astro-components",
-  "version": "2.1.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessible-astro-components",
-      "version": "2.1.0",
+      "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.7",


### PR DESCRIPTION
Adding in the missing aria-current attribute for a current page. The current page should also be a blank link (linking to itself)

Example:
https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/
