### PR TITLE
#68 - Dark Mode Accessible Name

### DIFF
--- a/DarkMode.astro
+++ b/DarkMode.astro
@@ -2,7 +2,7 @@
 type Props = Record<string, never>
 ---
 
-<button class="darkmode-toggle" aria-pressed="false" aria-label="Enable dark mode" transition:persist>
+<button class="darkmode-toggle" aria-pressed="false" aria-label="Toggle Dark Mode" transition:persist>
   <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"
     ><path
       fill="currentColor"
@@ -21,7 +21,6 @@ const enableDarkMode = (store = true) => {
   document.body.classList.add('darkmode')
   darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M13 3a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0V3zM5.707 4.293a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zm14 0a1 1 0 0 0-1.414 0l-1 1a1 1 0 0 0 1.414 1.414l1-1a1 1 0 0 0 0-1.414zM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm-9 4a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2H3zm17 0a1 1 0 1 0 0 2h1a1 1 0 1 0 0-2h-1zM6.707 18.707a1 1 0 1 0-1.414-1.414l-1 1a1 1 0 1 0 1.414 1.414l1-1zm12-1.414a1 1 0 0 0-1.414 1.414l1 1a1 1 0 0 0 1.414-1.414l-1-1zM13 20a1 1 0 1 0-2 0v1a1 1 0 1 0 2 0v-1z" fill="currentColor"/></svg>`
   darkModeToggle.setAttribute('aria-pressed', 'true')
-  darkModeToggle.setAttribute('aria-label', 'Disable dark mode')
   if (store) localStorage.setItem('darkMode', 'enabled')
 }
 
@@ -29,7 +28,6 @@ const disableDarkMode = (store = true) => {
   document.body.classList.remove('darkmode')
   darkModeToggle.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M9.353 3C5.849 4.408 3 7.463 3 11.47A9.53 9.53 0 0 0 12.53 21c4.007 0 7.062-2.849 8.47-6.353C8.17 17.065 8.14 8.14 9.353 3z"/></svg>`
   darkModeToggle.setAttribute('aria-pressed', 'false')
-  darkModeToggle.setAttribute('aria-label', 'Enable dark mode')
   if (store) localStorage.setItem('darkMode', 'disabled')
 }
 


### PR DESCRIPTION
As it stands the button toggles from aria-pressed="false" and aria-label="Enable dark mode" to aria-pressed="true" and aria-label="Disable dark mode" but we should not change the accessible name content.

References:
[Hidde De Vries How I built a dark mode toggle](https://hidde.blog/dark-light/)

> For toggle buttons, it is important that the content doesn't change. As the button text, I have used “Toggle dark mode”. If we would update the label of the button from “Turn on light” to “Turn on dark”, we kind of have a toggle ([as MDN suggests](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed#description)), but that way, it wouldn't be recognised by the browser and set in the accessibility tree to be a toggle, and, because of that, not announced as a toggle by screenreaders.

Resolution:
Leave the aria-label as "Toggle Dark Mode"

Close #68 