### PR TITLE
:sparkles: Allow rendering user-defined progress-text in `Pagination`

### DIFF
--- a/Pagination.astro
+++ b/Pagination.astro
@@ -10,7 +10,7 @@ interface Props {
   lastPage?: RouteString
   currentPage?: string | number
   totalPages?: NumericalString | number
-  renderProgress?: ({ currentPage, totalPages }: { currentPage: string; totalPages: string }) => string
+  renderProgress?: ({ currentPage, totalPages }: { currentPage: string | number; totalPages: string | number }) => string
 }
 
 const {

--- a/Pagination.astro
+++ b/Pagination.astro
@@ -10,6 +10,7 @@ interface Props {
   lastPage?: RouteString
   currentPage?: string | number
   totalPages?: NumericalString | number
+  renderProgress?: ({ currentPage, totalPages }: { currentPage: string; totalPages: string }) => string
 }
 
 const {
@@ -19,7 +20,10 @@ const {
   lastPage = '#',
   currentPage = '1',
   totalPages = '12',
+  renderProgress = ({ currentPage, totalPages }) => `Page ${currentPage} of ${totalPages}`
 } = Astro.props
+
+const progress = renderProgress({ currentPage, totalPages });
 ---
 
 <nav class="pagination" aria-label="Pagination">
@@ -113,7 +117,7 @@ const {
       }
     </li>
     <li>
-      <span>Page {currentPage} of {totalPages}</span>
+      <span>{progress}</span>
     </li>
     <li>
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessible-astro-components",
-  "version": "2.3.1",
+  "version": "2.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessible-astro-components",
-      "version": "2.3.1",
+      "version": "2.3.5",
       "license": "MIT",
       "devDependencies": {
         "prettier": "2.8.7",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -126,7 +126,8 @@ export const Notification: Notification
  * @param _props.nextPage - Falsy value = disabled link icon | `<a href={nextPage}>` route string such "/blog/2" - default: "#"
  * @param _props.lastPage - Falsy value = disabled link icon | `<a href={lastPage}>` route string such "/blog/20" - default: "#"
  * @param _props.currentPage - `<span>Page {currentPage} of {totalPages}</span>` - Default: '1'
- * @param _props.totalPages - `<span>Page {currentPage} of {totalPages}</span>` - Default: '12
+ * @param _props.totalPages - `<span>Page {currentPage} of {totalPages}</span>` - Default: '12'
+ * @param _props.renderProgress - `Function rendering the progress. Defaults to the string "Page {currentPage} of {totalPages}"`
  */
 type Pagination = typeof import('../index.js').Pagination
 export const Pagination: Pagination


### PR DESCRIPTION
... so users preferring a different translation or something like "1/10" can do that.